### PR TITLE
Fix index_resources (search) in administrate (0.17.0)

### DIFF
--- a/lib/administrate/base_controller.rb
+++ b/lib/administrate/base_controller.rb
@@ -55,7 +55,7 @@ module Administrate
     # +dashboard_class+ and +search_term+. Overwrite this to turn off search.
     #
     def index_resources
-      Administrate::Search.new(index_scoped_resource, dashboard_class, search_term).run
+      Administrate::Search.new(index_scoped_resource, dashboard, search_term).run
     end
 
     ##


### PR DESCRIPTION
Change from `dashboard_class` to `dashboard`.

```
NameError (uninitialized constant Class::ATTRIBUTE_TYPES
web     | 
web     |       @dashboard.class.const_get(:ATTRIBUTE_TYPES)
web     |                       ^^^^^^^^^^):
web     |   
web     | administrate (0.17.0) lib/administrate/search.rb:129:in `const_get'
web     | administrate (0.17.0) lib/administrate/search.rb:129:in `attribute_types'
web     | administrate (0.17.0) lib/administrate/search.rb:154:in `tables_to_join'
web     | administrate (0.17.0) lib/administrate/search.rb:116:in `search_results'
web     | administrate (0.17.0) lib/administrate/search.rb:61:in `run'
web     | administrate-base_controller (0.7.0) lib/administrate/base_controller.rb:58:in `index_resources'
web     | administrate-base_controller (0.7.0) lib/administrate/base_controller.rb:6:in `index'
```